### PR TITLE
Cancel Update

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,8 +91,9 @@ openTaskFormBtn.addEventListener("click", () =>
 
 closeTaskFormBtn.addEventListener("click", () => {
     const formInputsContainValues = titleInput.value || dateInput.value || descriptionInput.value;
+    const formInputValuesUpdated = titleInput.value !== currentTask.title || dateInput.value !== currentTask.date || descriptionInput.value !== currentTask.description;
 
-    if (formInputsContainValues) {
+    if (formInputsContainValues && formInputValuesUpdated) {
         confirmCloseDialog.showModal();
     } else {
         reset();


### PR DESCRIPTION
Cancel and Discard buttons in modal won't be displayed on browser if user did not update input fields in task form